### PR TITLE
Fix #24 Multiple regressions after last PRs

### DIFF
--- a/Archimate.puml
+++ b/Archimate.puml
@@ -52,6 +52,7 @@ skinparam archimate {
   RoundCorner<<strategy-course-of-action>> 25
   RoundCorner<<strategy-value-stream>> 25
   RoundCorner<<business-process>> 25
+  RoundCorner<<business-event>> 25
   RoundCorner<<business-function>> 25
   RoundCorner<<business-interaction>> 25
   RoundCorner<<business-event>> 25
@@ -107,7 +108,7 @@ skinparam usecase {
 ' Elements
 ' ##################################
 'Strategy Elements
-!define Strategy_Resource(e_alias, e_label) archimate #STRATEGY "e_label" <<strategy-resource>> as e_alias
+!define Strategy_Resource(e_alias, e_label) archimate #STRATEGY "....\n e_label" <<strategy-resource>> as e_alias
 !define Strategy_Capability(e_alias, e_label) archimate #STRATEGY "e_label" <<strategy-capability>> as e_alias
 !define Strategy_CourseOfAction(e_alias, e_label) archimate #STRATEGY "e_label" <<strategy-course-of-action>> as e_alias
 !define Strategy_ValueStream(e_alias, e_label) archimate #STRATEGY "e_label" <<strategy-value-stream>> as e_alias
@@ -122,9 +123,9 @@ skinparam usecase {
 !define Business_Interaction(e_alias, e_label) archimate #BUSINESS "e_label" <<business-interaction>> as e_alias
 !define Business_Event(e_alias, e_label) archimate #BUSINESS "e_label" <<business-event>> as e_alias
 !define Business_Service(e_alias, e_label) archimate #BUSINESS "e_label" <<business-service>> as e_alias
-!define Business_Object(e_alias, e_label) archimate #BUSINESS "e_label" <<business-object>> as e_alias
-!define Business_Contract(e_alias, e_label) archimate #BUSINESS "e_label" <<business-contract>> as e_alias
-!define Business_Representation(e_alias, e_label) archimate #BUSINESS "e_label" <<business-representation>> as e_alias
+!define Business_Object(e_alias, e_label) archimate #BUSINESS "----\n e_label" <<business-object>> as e_alias
+!define Business_Contract(e_alias, e_label) archimate #BUSINESS "----\n e_label\n----" <<business-contract>> as e_alias
+!define Business_Representation(e_alias, e_label) archimate #BUSINESS "----\n e_label" <<business-representation>> as e_alias
 !define Business_Product(e_alias, e_label) archimate #BUSINESS "e_label" <<business-product>> as e_alias
 !define Business_Location(e_alias, e_label) archimate #BUSINESS "e_label" <<business-location>> as e_alias
 
@@ -137,10 +138,10 @@ skinparam usecase {
 !define Application_Process(e_alias, e_label) archimate #APPLICATION "e_label" <<application-process>> as e_alias
 !define Application_Event(e_alias, e_label) archimate #APPLICATION "e_label" <<application-event>> as e_alias
 !define Application_Service(e_alias, e_label) archimate #APPLICATION "e_label" <<application-service>> as e_alias
-!define Application_DataObject(e_alias, e_label) archimate #APPLICATION "---\n e_label" <<application-data-object>> as e_alias
+!define Application_DataObject(e_alias, e_label) archimate #APPLICATION "----\n e_label" <<application-data-object>> as e_alias
 
 'Technology Elements
-!define Technology_Node(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-node>> as e_alias
+!define Technology_Node(e_alias, e_label) node #TECHNOLOGY "e_label" <<$archimate/technology-node>> as e_alias
 !define Technology_Device(e_alias, e_label) node #TECHNOLOGY "e_label" <<$archimate/technology-device>> as e_alias
 !define Technology_SystemSoftware(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-system-software>> as e_alias
 !define Technology_Collaboration(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-collaboration>> as e_alias
@@ -148,17 +149,17 @@ skinparam usecase {
 !define Technology_Path(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-communication-path>> as e_alias
 !define Technology_CommunicationNetwork(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-network>> as e_alias
 !define Technology_Function(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-function>> as e_alias
-!define Technology_Process(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<process>> as e_alias
-!define Technology_Interaction(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<interaction>> as e_alias
-!define Technology_Event(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<event>> as e_alias
+!define Technology_Process(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-process>> as e_alias
+!define Technology_Interaction(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-interaction>> as e_alias
+!define Technology_Event(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-event>> as e_alias
 !define Technology_Service(e_alias, e_label) archimate #TECHNOLOGY "e_label" <<technology-infra-service>> as e_alias
-!define Technology_Artifact(e_alias, e_label) archimate #TECHNOLOGY "---\n e_label" <<technology-artifact>> as e_alias
+!define Technology_Artifact(e_alias, e_label) archimate #TECHNOLOGY "----\n e_label" <<technology-artifact>> as e_alias
 
 'Physical Elements
-!define Physical_Equipment(e_alias, e_label) node #PHYSICAL "e_label" <<physical-equipment>> as e_alias
-!define Physical_Facility(e_alias, e_label) node #PHYSICAL "e_label" <<physical-facility>> as e_alias
+!define Physical_Equipment(e_alias, e_label) node #PHYSICAL "e_label" <<$archimate/physical-equipment>> as e_alias
+!define Physical_Facility(e_alias, e_label) node #PHYSICAL "e_label" <<$archimate/physical-facility>> as e_alias
 !define Physical_DistributionNetwork(e_alias, e_label) archimate #PHYSICAL "e_label" <<physical-distribution-network>> as e_alias
-!define Physical_Material(e_alias, e_label) archimate #PHYSICAL "---\n e_label" <<physical-material>> as e_alias
+!define Physical_Material(e_alias, e_label) archimate #PHYSICAL "----\n e_label" <<physical-material>> as e_alias
 
 'Motivation Elements
 !define Motivation_Stakeholder(e_alias, e_label) archimate #MOTIVATION "e_label" <<motivation-stakeholder>> as e_alias
@@ -174,17 +175,18 @@ skinparam usecase {
 
 'Implementation Elements
 !define Implementation_WorkPackage(e_alias, e_label) archimate #IMPLEMENTATION "e_label" <<implementation-workpackage>> as e_alias
-!define Implementation_Deliverable(e_alias, e_label) archimate #IMPLEMENTATION "---\n e_label" <<implementation-deliverable>> as e_alias
+!define Implementation_Deliverable(e_alias, e_label) archimate #IMPLEMENTATION "----\n e_label" <<implementation-deliverable>> as e_alias
 !define Implementation_Event(e_alias, e_label) archimate #IMPLEMENTATION "e_label" <<implementation-event>> as e_alias
 !define Implementation_Plateau(e_alias, e_label) node #PHYSICAL "e_label" <<$archimate/implementation-plateau>> as e_alias
-!define Implementation_Gap(e_alias, e_label) archimate #PHYSICAL "---\n e_label" <<implementation-gap>> as e_alias
+!define Implementation_Gap(e_alias, e_label) archimate #PHYSICAL "----\n e_label" <<implementation-gap>> as e_alias
 
 'Other Elements
-!define Other_Location(e_alias, e_label) archimate #OrangeRed "e_label" <<location>> as e_alias
+!define Other_Location(e_alias, e_label) archimate #ffb973 "e_label" <<location>> as e_alias
 !define Junction_Or(e_alias, e_label) circle #whitesmoke "e_label" as e_alias
 !define Junction_And(e_alias, e_label) circle #black "e_label" as e_alias
 !define Grouping(e_alias, e_label) Folder "e_label" <<grouping>> as e_alias
 !define Group(e_alias, e_label) Folder "e_label" <<group>> as e_alias
+
 
 ' Relationships
 ' ##################################
@@ -202,11 +204,11 @@ skinparam usecase {
 !define Rel_Aggregation_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "o-LEFT-")
 !define Rel_Aggregation_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "o-RIGHT-")
 
-!define Rel_Assignment(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-->")
-!define Rel_Assignment_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-UP->")
-!define Rel_Assignment_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-DOWN->")
-!define Rel_Assignment_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-LEFT->")
-!define Rel_Assignment_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-RIGHT->")
+!define Rel_Assignment(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-->>")
+!define Rel_Assignment_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-UP->>")
+!define Rel_Assignment_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-DOWN->>")
+!define Rel_Assignment_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-LEFT->>")
+!define Rel_Assignment_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "0-RIGHT->>")
 
 !define Rel_Specialization(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "--|>")
 !define Rel_Specialization_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "-UP-|>")
@@ -250,32 +252,32 @@ skinparam usecase {
 !define Rel_Triggering_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "-LEFT->>")
 !define Rel_Triggering_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "-RIGHT->>")
 
-!define Rel_Access(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".>") 
-!define Rel_Access_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".UP.>")
-!define Rel_Access_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".DOWN.>")
-!define Rel_Access_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".LEFT.>")
-!define Rel_Access_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".RIGHT.>")
+!define Rel_Access(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~~")
+!define Rel_Access_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~UP~")
+!define Rel_Access_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~DOWN~")
+!define Rel_Access_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~LEFT~")
+!define Rel_Access_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~RIGHT~")
 
-!define Rel_Influnce(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "->") 
-!define Rel_Influnce_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "-UP->")
-!define Rel_Influnce_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "-DOWN->")
-!define Rel_Influnce_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "-LEFT->")
-!define Rel_Influnce_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "-RIGHT->")
+!define Rel_Access_r(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-~")
+!define Rel_Access_r_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-UP~")
+!define Rel_Access_r_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-DOWN~")
+!define Rel_Access_r_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-LEFT~")
+!define Rel_Access_r_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-RIGHT~")
 
-!define Rel_Access_r(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~~")
-!define Rel_Access_r_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~UP~")
-!define Rel_Access_r_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~DOWN~")
-!define Rel_Access_r_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~LEFT~")
-!define Rel_Access_r_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~RIGHT~")
+!define Rel_Access_rw(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-->")
+!define Rel_Access_rw_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-UP->")
+!define Rel_Access_rw_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-DOWN->")
+!define Rel_Access_rw_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-LEFT->")
+!define Rel_Access_rw_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<-RIGHT->")
 
-!define Rel_Access_rw(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~~>")
-!define Rel_Access_rw_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~UP~>")
-!define Rel_Access_rw_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~DOWN.>")
-!define Rel_Access_rw_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~LEFT~>")
-!define Rel_Access_rw_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "<~RIGHT~>")
+!define Rel_Access_w(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~->")
+!define Rel_Access_w_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~UP->")
+!define Rel_Access_w_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~DOWN->")
+!define Rel_Access_w_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~LEFT->")
+!define Rel_Access_w_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~RIGHT->")
 
-!define Rel_Access_w(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~~>")
-!define Rel_Access_w_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~UP~>")
-!define Rel_Access_w_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~DOWN~>")
-!define Rel_Access_w_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~LEFT~>")
-!define Rel_Access_w_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "~RIGHT~>")
+!define Rel_Influence(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, "..>")
+!define Rel_Influence_Up(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".UP.>")
+!define Rel_Influence_Down(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".DOWN.>")
+!define Rel_Influence_Left(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".LEFT.>")
+!define Rel_Influence_Right(e_From, e_To, e_label="") Rel_(e_From, e_To, e_label, ".RIGHT.>")


### PR DESCRIPTION
## List of changes:

* Fix typo: Influnce → Influence    
* Fix assignment arrowhead
* Fix access dotted line
* Revert specific technology-process/interaction/event icons, which now work because they where added in plantuml/plantuml#205, finally fixing #5
* Add missing rounded corners for: business-event related #11
* Add missing horizontal lines according to spec to Business_Contrat, Business_Object & Business_Representation
* Fix icons for Technology_Device
* Remove unneeded horizontal lines according to spec, from Material, .... TODO
* Change Location color from #OrangeRed to #ffb973 according to spec
* Change Other_Location to Location. Add Other_Location as an alias to maintain backwards compatibility
* Added dotted line separator to StrategyResource header to indicate its Passive & Active double nature
* Use 4 characters everywhere to represent the solid and dotted line separators for consistency
* Increase header number version and add the file URL

## The result:

![elements](https://user-images.githubusercontent.com/5832068/80914572-9da3a580-8d4c-11ea-81f6-4f2f216f1135.png)

![arrows](https://user-images.githubusercontent.com/5832068/80914427-b2cc0480-8d4b-11ea-8b12-f683bf632326.png)

## Overview refence, for comparison:
![overview](https://user-images.githubusercontent.com/5832068/80914443-d1ca9680-8d4b-11ea-89ae-91ff0cbf5c48.png)
